### PR TITLE
Valid move

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -6,7 +6,14 @@ class PiecesController < ApplicationController
 
   def update
     piece = Piece.find(params[:id])
-    piece.update_attributes(piece_params)
+    Rails.logger.debug "PIECE Controller Update. call move_to"
+
+    if piece.move_to!(piece_params[:row].to_i, piece_params[:col].to_i)
+      Rails.logger.debug "VALID MOVE. Update Record - "SQL update in server window"
+      piece.update_attributes(piece_params)  # this is the line that calls the jQuery $.post
+    else
+      Rails.logger.debug "INVALID MOVE. "Do not update record. Piece will pop back on game page refresh"
+    end
     render json: piece
   end
 

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -6,13 +6,13 @@ class PiecesController < ApplicationController
 
   def update
     piece = Piece.find(params[:id])
-    Rails.logger.debug "PIECE Controller Update. call move_to"
+    Rails.logger.debug "PIECE Controller Update. call move_to in pieces model"
 
     if piece.move_to!(piece_params[:row].to_i, piece_params[:col].to_i)
-      Rails.logger.debug "VALID MOVE. Update Record - "SQL update in server window"
-      piece.update_attributes(piece_params)  # this is the line that calls the jQuery $.post
+      Rails.logger.debug "VALID MOVE. Update Record - SQL update in server window"
+      piece.update_attributes(piece_params)
     else
-      Rails.logger.debug "INVALID MOVE. "Do not update record. Piece will pop back on game page refresh"
+      Rails.logger.debug "INVALID MOVE. Do not update record. Piece will pop back on game page refresh"
     end
     render json: piece
   end

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -8,12 +8,8 @@ class PiecesController < ApplicationController
     piece = Piece.find(params[:id])
     Rails.logger.debug "PIECE Controller Update. call move_to in pieces model"
 
-    if piece.move_to!(piece_params[:row].to_i, piece_params[:col].to_i)
-      Rails.logger.debug "VALID MOVE. Update Record - SQL update in server window"
-      piece.update_attributes(piece_params)
-    else
-      Rails.logger.debug "INVALID MOVE. Do not update record. Piece will pop back on game page refresh"
-    end
+    piece.move_to!(piece_params[:row].to_i, piece_params[:col].to_i)
+
     render json: piece
   end
 

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -6,7 +6,6 @@ class PiecesController < ApplicationController
 
   def update
     piece = Piece.find(params[:id])
-    Rails.logger.debug "PIECE Controller Update. call move_to in pieces model"
 
     piece.move_to!(piece_params[:row].to_i, piece_params[:col].to_i)
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,6 +1,5 @@
 # rubocop:disable Metrics/AbcSize
 # rubocop:disable Metrics/MethodLength
-# rubocop:disable LineLength
 
 class Game < ApplicationRecord
   has_many :participations

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -1,6 +1,5 @@
 class King < Piece
   def move_legal?(to_row, to_col)
-    Rails.logger.debug "KING move_legal"
     row_diff = (row - to_row).abs
     col_diff = (col - to_col).abs
     row_diff <= 1 && col_diff <= 1

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -1,2 +1,9 @@
 class King < Piece
+   def move_legal?(to_row,to_col)
+    Rails.logger.debug "KING move_legal"
+    row_diff = (self.row - to_row).abs
+    col_diff = (self.col - to_col).abs
+    row_diff <= 1 && col_diff <= 1
+  end   # method move_legal?
+
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -16,18 +16,15 @@ class Piece < ApplicationRecord
   end
 
   def move_to!(to_row, to_col)
-    # rubocop: disable LineLength
     Rails.logger.debug "Model move_to. from: #{row},#{col} to: #{to_row},#{to_col}"
 
-    if valid_move?(to_row, to_col)
-      from_row = row   # needed for create_move if valid_move? true
-      from_col = col   # needed for create_move if valid_move? true
-      Rails.logger.debug "valid_move result TRUE. Piece stays at new location."
-      update_attributes(row: to_row, col: to_col)
-      create_move!(from_row, from_col)
-    else
-      Rails.logger.debug "valid move result FALSE. Piece pop back when games show page reloaded."
-    end # method move_to!
+    return unless valid_move?(to_row, to_col)
+
+    from_row = row   # needed for create_move if valid_move? true
+    from_col = col   # needed for create_move if valid_move? true
+    Rails.logger.debug "valid_move result TRUE. Piece stays at new location."
+    update_attributes(row: to_row, col: to_col)
+    create_move!(from_row, from_col)
   end   # method move_to!
 
   private
@@ -37,7 +34,7 @@ class Piece < ApplicationRecord
     return false if move_out_of_bounds?(to_row, to_col)
     return false unless move_legal?(to_row, to_col)
     return false if move_obstructed?(to_row, to_col)
-    return false if move_destination_obstructed(to_row, to_col)
+    return false if move_destination_obstructed?(to_row, to_col)
     true
   end   # method valid_move?
 
@@ -66,7 +63,7 @@ class Piece < ApplicationRecord
     false
   end   # move_obstructed
 
-  def move_destination_obstructed(_to_row, _to_col)
+  def move_destination_obstructed?(_to_row, _to_col)
     false
   end # method move_destination_obstructed
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -15,7 +15,7 @@ class Piece < ApplicationRecord
     super.merge("type" => type)
   end
 
-  def move_to!(row, col)
+  def move_to!(to_row, to_col)
     Rails.logger.debug "Model move_to. from location: #{self.row},#{self.col} to location: #{to_row},#{to_col}"
 
     if valid_move?(to_row,to_col)

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -16,7 +16,57 @@ class Piece < ApplicationRecord
   end
 
   def move_to!(row, col)
-    raise "Out of bounds" if row < 0 || row > 7 || col < 0 || col > 7
-    update(row: row, col: col)
+    Rails.logger.debug "Model move_to. from location: #{self.row},#{self.col} to location: #{to_row},#{to_col}"
+
+    if valid_move?(to_row,to_col)
+      Rails.logger.debug "valid_move result TRUE. Piece stays at new location. controller update UPDATES table."
+      # use update_attributes in controller update method instead update(row: to_row, col: to_col)
+      self.row = to_row
+      self.col = to_col
+      return true
+
+    else
+      Rails.logger.debug "valid move result FALSE. Piece should pop back to original location. controller update does NOT update table."
+      return false
+    end   # method move_to!
+
+    # origin code
+    # raise "Out of bounds" if row < 0 || row > 7 || col < 0 || col > 7
+    # update(row: row, col: col)
   end
+
+  def valid_move?(to_row,to_col)
+    return false if move_nil?(to_row,to_col)
+    return false if move_out_of_bounds?(to_row,to_col)
+    return false unless move_legal?(to_row,to_col)
+    return false if move_obstructed?(to_row,to_col)
+    return false if move_destination_obstructed(to_row,to_col)
+    return true
+  end   # method valid_move?
+
+  def move_nil?(to_row, to_col)
+    self.row == to_row && self.col == to_col
+  end   # method move_nil?
+
+  def move_out_of_bounds?(to_row,to_col)
+    to_row < 0 || to_row > 7 || to_col < 0 || to_row > 7
+  end   # method move_out_of_bounds?
+
+  def move_legal?(to_row,to_col)
+    # Piece sub-classes MUST implement move_legal? method. See King.rb for example
+    # fail NotImplementedError 'Piece sub-class must implement #legal_move?'
+    # Will remove comment and following code once all sub-classes are complete.
+
+    self.row == to_row || self.col == to_col || (self.row-to_row).abs == (self.col-to_col).abs
+
+  end   # method move_legal
+
+  def move_obstructed?(to_row,to_col)
+    return false
+  end   # move_obstructed
+
+  def move_destination_obstructed(to_row,to_col)
+    return false
+  end   # move_destination_obstructed
+
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -18,16 +18,13 @@ class Piece < ApplicationRecord
   end
 
   def move_to!(to_row, to_col)
-    Rails.logger.debug "Model move_to. from: #{row},#{col} to: #{to_row},#{to_col}"
-
     return unless valid_move?(to_row, to_col)
 
-    from_row = row   # needed for create_move if valid_move? true
-    from_col = col   # needed for create_move if valid_move? true
-    Rails.logger.debug "valid_move result TRUE. Piece stays at new location."
+    from_row = row
+    from_col = col
     update_attributes(row: to_row, col: to_col)
     create_move!(from_row, from_col)
-  end   # method move_to!
+  end
 
   def capture_piece(row, col)
     other_piece = game.piece_at(row, col)
@@ -51,19 +48,18 @@ class Piece < ApplicationRecord
     return false if move_nil?(to_row, to_col)
     return false if move_out_of_bounds?(to_row, to_col)
     return false unless move_legal?(to_row, to_col)
-    return false if move_obstructed?(to_row, to_col)
     return false if move_destination_obstructed?(to_row, to_col)
+    return false if move_obstructed?(to_row, to_col)
     true
-  end   # method valid_move?
+  end
 
   def move_nil?(to_row, to_col)
-    Rails.logger.debug "NIL MOVE"
     row == to_row && col == to_col
-  end   # method move_nil?
+  end
 
   def move_out_of_bounds?(to_row, to_col)
     to_row < 0 || to_row > 7 || to_col < 0 || to_col > 7
-  end   # method move_out_of_bounds?
+  end
 
   def move_legal?(to_row, to_col)
     # Piece sub-classes MUST implement move_legal? method. See King.rb for example
@@ -75,15 +71,15 @@ class Piece < ApplicationRecord
     else
       row == to_row || col == to_col || (row - to_row).abs == (col - to_col).abs
     end
-  end   # method move_legal
-
-  def move_obstructed?(_to_row, _to_col)
-    false
-  end   # move_obstructed
+  end
 
   def move_destination_obstructed?(_to_row, _to_col)
     false
-  end # method move_destination_obstructed
+  end
+
+  def move_obstructed?(_to_row, _to_col)
+    false
+  end
 
   def create_move!(from_row, from_col)
     last_move_number = game.moves.last ? game.moves.last.move_number : 0
@@ -94,5 +90,5 @@ class Piece < ApplicationRecord
       move_type: nil, # to be implemented later
       game_id: game.id
     )
-  end # method create_move!
+  end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -23,6 +23,7 @@ class Piece < ApplicationRecord
       from_col = self.col   # needed for create_move if valid_move? true
       Rails.logger.debug "valid_move result TRUE. Piece stays at new location. controller update UPDATES table."
       update_attributes(row: to_row, col: to_col)
+      # create_move(from_row,to_row)
     else
       Rails.logger.debug "valid move result FALSE. Piece should pop back to original location. controller update does NOT update database table."
     end   # method move_to!

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -1,5 +1,3 @@
-# rubocop:disable LineLength
-
 class Piece < ApplicationRecord
   belongs_to :user
   belongs_to :game

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -19,15 +19,12 @@ class Piece < ApplicationRecord
     Rails.logger.debug "Model move_to. from location: #{self.row},#{self.col} to location: #{to_row},#{to_col}"
 
     if valid_move?(to_row,to_col)
+      from_row = self.row   # needed for create_move if valid_move? true
+      from_col = self.col   # needed for create_move if valid_move? true
       Rails.logger.debug "valid_move result TRUE. Piece stays at new location. controller update UPDATES table."
-      # use update_attributes in controller update method instead update(row: to_row, col: to_col)
-      self.row = to_row
-      self.col = to_col
-      return true
-
+      update_attributes(row: to_row, col: to_col)
     else
-      Rails.logger.debug "valid move result FALSE. Piece should pop back to original location. controller update does NOT update table."
-      return false
+      Rails.logger.debug "valid move result FALSE. Piece should pop back to original location. controller update does NOT update database table."
     end   # method move_to!
 
     # origin code
@@ -57,7 +54,11 @@ class Piece < ApplicationRecord
     # fail NotImplementedError 'Piece sub-class must implement #legal_move?'
     # Will remove comment and following code once all sub-classes are complete.
 
-    self.row == to_row || self.col == to_col || (self.row-to_row).abs == (self.col-to_col).abs
+    if (self.type == "Knight")
+      return true
+    else
+      self.row == to_row || self.col == to_col || (self.row-to_row).abs == (self.col-to_col).abs
+    end
 
   end   # method move_legal
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -42,11 +42,12 @@ class Piece < ApplicationRecord
   end   # method valid_move?
 
   def move_nil?(to_row, to_col)
+    Rails.logger.debug "NIL MOVE"
     row == to_row && col == to_col
   end   # method move_nil?
 
   def move_out_of_bounds?(to_row, to_col)
-    to_row < 0 || to_row > 7 || to_col < 0 || to_row > 7
+    to_row < 0 || to_row > 7 || to_col < 0 || to_col > 7
   end   # method move_out_of_bounds?
 
   def move_legal?(to_row, to_col)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,5 +52,5 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,4 @@
-Rails.application.configure do
+environmeRails.application.configure do
   config.action_mailer.default_url_options = { host: 'localhost:3030' }
 
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,5 +52,5 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::FileUpdateChecker
+  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe King, type: :model do
-
   describe '#move_legal?' do
     from_row = 0
     from_col = 4
@@ -9,23 +8,22 @@ RSpec.describe King, type: :model do
     let(:king) { King.create(row: from_row, col: from_col) }
 
     it "allows King legal move: horizontal" do
-      expect(king.move_legal?(from_row, from_col+1)).to be true
+      expect(king.move_legal?(from_row, from_col + 1)).to be true
     end
 
     it "allows legal move: vertical" do
       king.update_attributes(row: from_row, col: from_col)
-      expect(king.move_legal?(from_row+1, from_col)).to be true
+      expect(king.move_legal?(from_row + 1, from_col)).to be true
     end
 
     it "allows legal move: diagonal" do
       king.update_attributes(row: from_row, col: from_col)
-      expect(king.move_legal?(from_row+1, from_col+1)).to be true
+      expect(king.move_legal?(from_row + 1, from_col + 1)).to be true
     end
 
     it "does not allow not legal move" do
       king.update_attributes(row: from_row, col: from_col)
-      expect(king.move_legal?(from_row+2, from_col+3)).to be false
+      expect(king.move_legal?(from_row + 2, from_col + 3)).to be false
     end
-
   end
- end
+end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe Piece, type: :model do
       piece = @game.pieces.create(
         row: from_row, col: from_col, is_captured: false, user: @user
       )
+      # rubocop: disable LineLength
       expect(piece.send(:move_out_of_bounds?, from_row + 1, from_col + 1)).to be false
     end
 

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe Piece, type: :model do
     end
 
     # MeO tests for move_to! - test valid_move? and its called methods
-    from_row = 3
-    from_col = 2
+    FROM_ROW = 3
+    FROM_COL = 2
 
     # PRIVATE method move_nil?
     it "tests private method move_nil? with a nil move" do

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -53,19 +53,67 @@ RSpec.describe Piece, type: :model do
     # MeO tests for move_to! - test valid_move? and its called methods
     from_row = 3
     from_col = 2
-    it "should not move the piece: nil move" do
+
+    # PRIVATE method move_nil?
+    it "tests private method move_nil? with a nil move" do
       piece = @game.pieces.create(
         row: from_row, col: from_col, is_captured: false, user: @user
       )
-      piece.move_to!(from_row, from_col)
+      expect(piece.send(:move_nil?, from_row, from_col)).to be true
+    end
+    it "tests private method move_nil? with a non-nil move" do
+      piece = @game.pieces.create(
+        row: from_row, col: from_col, is_captured: false, user: @user
+      )
+      expect(piece.send(:move_nil?, 7, 7)).to be false
+    end
+
+    # PRIVATE method move_out_bounds
+    it "tests private method move_out_of_bounds? with an off-board move" do
+      piece = @game.pieces.create(
+        row: from_row, col: from_col, is_captured: false, user: @user
+      )
+      expect(piece.send(:move_out_of_bounds?, from_row, 8)).to be true
+    end
+    it "tests private method move_out_of_bounds? with an on-board move" do
+      piece = @game.pieces.create(
+        row: from_row, col: from_col, is_captured: false, user: @user
+      )
+      expect(piece.send(:move_out_of_bounds?, from_row + 1, from_col + 1)).to be false
+    end
+
+    # Private method valid_move?
+    it "tests private method valid_move? with a nil move" do
+      piece = @game.pieces.create(
+        row: from_row, col: from_col, is_captured: false, user: @user
+      )
+      expect(piece.send(:valid_move?, from_row, from_col)).to be false
+    end
+
+    it "tests private method valid_move? with an out of bounds move" do
+      piece = @game.pieces.create(
+        row: from_row, col: from_col, is_captured: false, user: @user
+      )
+      expect(piece.send(:valid_move?, from_row, 8)).to be false
+    end
+
+    # move_to! with an out-of-bounds move
+    it "should not move the piece out of bounds" do
+      to_col = 8
+      piece = @game.pieces.create(
+        row: from_row, col: from_col, is_captured: false, user: @user
+      )
+      piece.move_to!(from_row, to_col)
       expect(piece.row).to eq(from_row)
       expect(piece.col).to eq(from_col)
     end
-    it "should not move the piece: out of bounds move" do
+
+    # remove test after all piece subclass tests complete
+    it "should not move the piece due to illegal move" do
       piece = @game.pieces.create(
         row: from_row, col: from_col, is_captured: false, user: @user
       )
-      piece.move_to!(8, 8)
+      piece.move_to!(from_row + 2, from_col + 1)
       expect(piece.row).to eq(from_row)
       expect(piece.col).to eq(from_col)
     end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -53,34 +53,39 @@ RSpec.describe Piece, type: :model do
     # MeO tests for move_to! - test valid_move? and its called methods
     from_row = 3
     from_col = 2
-
     it "should not move the piece: nil move" do
-      piece = @game.pieces.create(row: from_row, col: from_col, is_captured: false, user: @user)
-      piece.move_to!(from_row,from_col)
+      piece = @game.pieces.create(
+        row: from_row, col: from_col, is_captured: false, user: @user
+      )
+      piece.move_to!(from_row, from_col)
       expect(piece.row).to eq(from_row)
       expect(piece.col).to eq(from_col)
     end
-
     it "should not move the piece: out of bounds move" do
-      piece = @game.pieces.create(row: from_row, col: from_col, is_captured: false, user: @user)
-      piece.move_to!(8,8)
+      piece = @game.pieces.create(
+        row: from_row, col: from_col, is_captured: false, user: @user
+      )
+      piece.move_to!(8, 8)
       expect(piece.row).to eq(from_row)
       expect(piece.col).to eq(from_col)
     end
-
     # remove test after all piece subclass tests complete
     it "should move the piece: horizonal move" do
       to_col = 7
-      piece = @game.pieces.create(row: from_row, col: from_col, is_captured: false, user: @user)
-      piece.move_to!(from_row,to_col)
+      piece = @game.pieces.create(
+        row: from_row, col: from_col, is_captured: false, user: @user
+      )
+      piece.move_to!(from_row, to_col)
       expect(piece.row).to eq(from_row)
       expect(piece.col).to eq(to_col)
     end
     # remove test after all piece subclass tests complete
     it "should move the piece: vertical move" do
       to_row = 7
-      piece = @game.pieces.create(row: from_row, col: from_col, is_captured: false, user: @user)
-      piece.move_to!(to_row,from_col)
+      piece = @game.pieces.create(
+        row: from_row, col: from_col, is_captured: false, user: @user
+      )
+      piece.move_to!(to_row, from_col)
       expect(piece.row).to eq(to_row)
       expect(piece.col).to eq(from_col)
     end
@@ -88,26 +93,12 @@ RSpec.describe Piece, type: :model do
     it "should move the piece: diagonal move" do
       to_row = 6
       to_col = 5
-      piece = @game.pieces.create(row: from_row, col: from_col, is_captured: false, user: @user)
-      piece.move_to!(to_row,to_col)
+      piece = @game.pieces.create(
+        row: from_row, col: from_col, is_captured: false, user: @user
+      )
+      piece.move_to!(to_row, to_col)
       expect(piece.row).to eq(to_row)
       expect(piece.col).to eq(to_col)
     end
   end
 end
-
-
-
-#RSpec.describe Bishop, type: :model do
-#  describe '#move_legal?' do
-#    let(:bishop) { Bishop.create(row: 3, col: 3) }
-
-#    it "allows legal moves" do
-#      expect(bishop.move_legal?(6, 6)).to be true
-#    end
-
-#    it "does not allow not legal moves" do
-#      expect(bishop.move_legal?(4, 5)).to be false
-#    end
-#  end
-# end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -57,13 +57,13 @@ RSpec.describe Piece, type: :model do
     # PRIVATE method move_nil?
     it "tests private method move_nil? with a nil move" do
       piece = @game.pieces.create(
-        row: from_row, col: from_col, is_captured: false, user: @user
+        row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
       )
-      expect(piece.send(:move_nil?, from_row, from_col)).to be true
+      expect(piece.send(:move_nil?, FROM_ROW, FROM_COL)).to be true
     end
     it "tests private method move_nil? with a non-nil move" do
       piece = @game.pieces.create(
-        row: from_row, col: from_col, is_captured: false, user: @user
+        row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
       )
       expect(piece.send(:move_nil?, 7, 7)).to be false
     end
@@ -71,79 +71,78 @@ RSpec.describe Piece, type: :model do
     # PRIVATE method move_out_bounds
     it "tests private method move_out_of_bounds? with an off-board move" do
       piece = @game.pieces.create(
-        row: from_row, col: from_col, is_captured: false, user: @user
+        row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
       )
-      expect(piece.send(:move_out_of_bounds?, from_row, 8)).to be true
+      expect(piece.send(:move_out_of_bounds?, FROM_ROW, 8)).to be true
     end
     it "tests private method move_out_of_bounds? with an on-board move" do
       piece = @game.pieces.create(
-        row: from_row, col: from_col, is_captured: false, user: @user
+        row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
       )
-      # rubocop: disable LineLength
-      expect(piece.send(:move_out_of_bounds?, from_row + 1, from_col + 1)).to be false
+      expect(piece.send(:move_out_of_bounds?, FROM_ROW + 1, FROM_COL + 1)).to be false
     end
 
     # Private method valid_move?
     it "tests private method valid_move? with a nil move" do
       piece = @game.pieces.create(
-        row: from_row, col: from_col, is_captured: false, user: @user
+        row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
       )
-      expect(piece.send(:valid_move?, from_row, from_col)).to be false
+      expect(piece.send(:valid_move?, FROM_ROW, FROM_COL)).to be false
     end
 
     it "tests private method valid_move? with an out of bounds move" do
       piece = @game.pieces.create(
-        row: from_row, col: from_col, is_captured: false, user: @user
+        row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
       )
-      expect(piece.send(:valid_move?, from_row, 8)).to be false
+      expect(piece.send(:valid_move?, FROM_ROW, 8)).to be false
     end
 
     # move_to! with an out-of-bounds move
     it "should not move the piece out of bounds" do
       to_col = 8
       piece = @game.pieces.create(
-        row: from_row, col: from_col, is_captured: false, user: @user
+        row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
       )
-      piece.move_to!(from_row, to_col)
-      expect(piece.row).to eq(from_row)
-      expect(piece.col).to eq(from_col)
+      piece.move_to!(FROM_ROW, to_col)
+      expect(piece.row).to eq(FROM_ROW)
+      expect(piece.col).to eq(FROM_COL)
     end
 
     # remove test after all piece subclass tests complete
     it "should not move the piece due to illegal move" do
       piece = @game.pieces.create(
-        row: from_row, col: from_col, is_captured: false, user: @user
+        row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
       )
-      piece.move_to!(from_row + 2, from_col + 1)
-      expect(piece.row).to eq(from_row)
-      expect(piece.col).to eq(from_col)
+      piece.move_to!(FROM_ROW + 2, FROM_COL + 1)
+      expect(piece.row).to eq(FROM_ROW)
+      expect(piece.col).to eq(FROM_COL)
     end
     # remove test after all piece subclass tests complete
     it "should move the piece: horizonal move" do
       to_col = 7
       piece = @game.pieces.create(
-        row: from_row, col: from_col, is_captured: false, user: @user
+        row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
       )
-      piece.move_to!(from_row, to_col)
-      expect(piece.row).to eq(from_row)
+      piece.move_to!(FROM_ROW, to_col)
+      expect(piece.row).to eq(FROM_ROW)
       expect(piece.col).to eq(to_col)
     end
     # remove test after all piece subclass tests complete
     it "should move the piece: vertical move" do
       to_row = 7
       piece = @game.pieces.create(
-        row: from_row, col: from_col, is_captured: false, user: @user
+        row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
       )
-      piece.move_to!(to_row, from_col)
+      piece.move_to!(to_row, FROM_COL)
       expect(piece.row).to eq(to_row)
-      expect(piece.col).to eq(from_col)
+      expect(piece.col).to eq(FROM_COL)
     end
     # remove test after all piece subclass tests complete
     it "should move the piece: diagonal move" do
       to_row = 6
       to_col = 5
       piece = @game.pieces.create(
-        row: from_row, col: from_col, is_captured: false, user: @user
+        row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
       )
       piece.move_to!(to_row, to_col)
       expect(piece.row).to eq(to_row)


### PR DESCRIPTION
method valid_move implemented in model pieces.rb. It calls in order move_nil?, move_out_of_bounds?, move_legal?, move_obstructed?, move_destination_obstructed?

Throughout my code I have added some Rails.logger.debug statements. They will appear in the server window and in the development log. 

Each of you will implement move_legal? for your piece. I have done it in king.rb. Once you are all done, I will uncomment the failNotImplementedError and remove the line that allows horizontal, vertical and diagonal as legal. I don't know if this will interfere with Knight::move_legal?

I made some changes in pieces_controller.rb update method from the master and the move_to method in pieces.rb. I apologize if I've stepped on toes here. move_to! now returns as boolean to the controller which means that I've also changed the move_to! method in the model so that it will return a boolean. 

What I don't have working yet is returning the piece to its original location when the move is invalid. You will see it pop back on a games page refresh. I haven't figured out how to pop it back with JavaScript. That might not be my task to do.

I also have a change in config/environments/development.rb on the last line. This line fixes my problem with restarting the server for each code change.