### PR TITLE
Increase rubocop max line length to 100 characters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,3 +25,6 @@ Style/EmptyMethod:
 
 Style/StringLiterals:
   Enabled: false
+
+Metrics/LineLength:
+  Max: 100


### PR DESCRIPTION
100 chars is more sane than the default 80