### PR TITLE
Move obstructed

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -7,7 +7,6 @@ class PiecesController < ApplicationController
   def update
     piece = Piece.find(params[:id])
 
-    Rails.logger.debug "CONTROLLER UPDATE. BEFORE CALL move_to"
     piece.move_to!(piece_params[:row].to_i, piece_params[:col].to_i)
 
     render json: piece

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -7,6 +7,7 @@ class PiecesController < ApplicationController
   def update
     piece = Piece.find(params[:id])
 
+    Rails.logger.debug "CONTROLLER UPDATE. BEFORE CALL move_to"
     piece.move_to!(piece_params[:row].to_i, piece_params[:col].to_i)
 
     render json: piece

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -7,7 +7,11 @@ class PiecesController < ApplicationController
   def update
     piece = Piece.find(params[:id])
 
-    piece.move_to!(piece_params[:row].to_i, piece_params[:col].to_i)
+    if piece.move_to!(piece_params[:row].to_i, piece_params[:col].to_i)
+      Rails.logger.debug "Piece move to #{piece.row}, #{piece.col} is GOOD"
+    else
+      Rails.logger.debug "ERROR. PIECE SHOULD NOT MOVE"
+    end
 
     render json: piece
   end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -3,5 +3,5 @@ class King < Piece
     row_diff = (row - to_row).abs
     col_diff = (col - to_col).abs
     row_diff <= 1 && col_diff <= 1
-  end # method move_legal?
+  end
 end

--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -1,8 +1,11 @@
 class Knight < Piece
   def move_legal?(to_row, to_col)
-    logger.debug "KNIGHT move_legal?"
     return false if row == to_row
     return false if col == to_col
     (row - to_row).abs + (col - to_col).abs == 3
+  end
+
+  def move_obstructed?(_to_row, _to_col)
+    false
   end
 end

--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -1,2 +1,8 @@
 class Knight < Piece
+  def move_legal?(to_row, to_col)
+    logger.debug "KNIGHT move_legal?"
+    return false if row == to_row
+    return false if col == to_col
+    (row - to_row).abs + (col - to_col).abs == 3
+  end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -125,6 +125,9 @@ class Piece < ApplicationRecord
         true
       else
         Rails.logger.debug "Destination contains opponent piece. capture possible."
+
+        # call capture logic
+        other_piece.update(is_captured: true)
         false
       end
     else
@@ -138,7 +141,7 @@ class Piece < ApplicationRecord
   # moved capture piece methods to private - after verify that move to new square is valid
   def capture_piece(row, col)
     other_piece = game.piece_at(row, col)
-    raise 'You cannot capture your own piece' if other_piece && other_piece.user == user
+    # raise 'You cannot capture your own piece' if other_piece && other_piece.user == user
     other_piece.captured!
     return true if other_piece && other_piece.user != user
   end
@@ -150,7 +153,7 @@ class Piece < ApplicationRecord
 
   def captured?
     is_captured == true
-end
+  end
 
 
   def create_move!(from_row, from_col)

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -16,9 +16,6 @@ class Piece < ApplicationRecord
   end
 
   def move_to!(to_row, to_col)
-    logger.debug "piece model. move_to! destination: #{to_row},#{to_col}"
-
-    logger.debug "before call to valid_move?"
     return false unless valid_move?(to_row, to_col)
 
     capture_piece(to_row, to_col)
@@ -45,7 +42,6 @@ class Piece < ApplicationRecord
   private
 
   def valid_move?(to_row, to_col)
-    logger.debug "inside valid_move"
     return false if move_nil?(to_row, to_col)
     return false if move_out_of_bounds?(to_row, to_col)
     return false if move_destination_ally?(to_row, to_col)

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -45,12 +45,8 @@ class Piece < ApplicationRecord
     return false if move_nil?(to_row, to_col)
     return false if move_out_of_bounds?(to_row, to_col)
     return false if move_destination_ally?(to_row, to_col)
-
-    # until have Knight::move_legal?
-    return true if type == "Knight"
-
     return false unless move_legal?(to_row, to_col)
-    return false if move_obstructed?(to_row, to_col)
+    return false if move_obstructed?(to_row, to_col) && type != 'Knight'
     true
   end
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -26,8 +26,7 @@ class Piece < ApplicationRecord
 
     # from_row = row
     # from_col = col
-    # update_attributes(row: to_row, col: to_col)
-
+    update_attributes(row: to_row, col: to_col)
 
     # create_move!(from_row, from_col)
   end
@@ -52,7 +51,7 @@ class Piece < ApplicationRecord
     return false if move_out_of_bounds?(to_row, to_col)
     return false if move_destination_ally?(to_row, to_col)
     return false unless move_legal?(to_row, to_col)
-    # return false if move_obstructed?(to_row, to_col)
+    return false if move_obstructed?(to_row, to_col)
     true
   end
 
@@ -84,28 +83,18 @@ class Piece < ApplicationRecord
   end
 
   def move_obstructed?(to_row, to_col)
-    Rails.logger.debug "***** Move_obstructed from #{row},#{col} to #{to_row},#{to_col}"
-    if type == "Knight"
-      Rails.logger.debug "KNIGHT. cannot obstruct move"
-      false
-    end
+    row_direction = to_row <=> row
+    col_direction = to_col <=> col
 
-    obstruction_array = []
-    if row == to_row
-      obstruction_array = move_obstructed_horizontal(to_col)
-    elsif col == to_col
-      obstruction_array = move_obstructed_vertical(to_row)
-    elsif (row - to_row).abs == (col - to_col).abs
-      obstruction_array = move_obstructed_diagonal(to_row, to_col)
-    end
+    # move one square off the current piece's square.
+    current_row = row + row_direction
+    current_col = col + col_direction
 
-    Rails.logger.debug "Obstruction array contains #{obstruction_array.size} elements"
-    return false if obstruction_array.empty?
-    obstruction_array.each do |square|
-      if game.piece_at(square[0], square[1])
-        Rails.logger.debug "OBSTRUCTION at #{square[0]}, #{square[1]}"
-      end
-      return true if game.piece_at(square[0], square[1])
+    # continue until square before destination. NOT looking at the destination square
+    until current_row == to_row - row_direction && current_col == to_col - col_direction
+      return true if game.piece_at(current_row, current_col)
+      current_row += row_direction
+      current_col += col_direction
     end
     false
   end
@@ -130,44 +119,4 @@ class Piece < ApplicationRecord
     ally = game.piece_at(check_row, check_col)
     ally if ally && ally.is_black == is_black
   end
-
-  def move_obstructed_horizontal(to_col)
-    obstruction_array = []
-    col_direction = to_col > col ? 1 : -1
-    current_col = col + col_direction
-    while (to_col - current_col).abs > 0
-      obstruction_array << [row, current_col]
-      current_col += col_direction
-    end
-    Rails.logger.debug "Horizonal Move. Inspect #{obstruction_array.size} squares"
-    obstruction_array
-  end
-
-  def move_obstructed_vertical(to_row)
-    obstruction_array = []
-    row_direction = to_row > row ? 1 : -1
-    current_row = row + row_direction
-    while (to_row - current_row).abs > 0
-      obstruction_array << [current_row, col]
-      current_row += row_direction
-    end
-    Rails.logger.debug "Vertical Move. Inspect #{obstruction_array.size} squares"
-    obstruction_array
-  end
-
-  def move_obstructed_diagonal(to_row, to_col)
-    obstruction_array = []
-    col_direction = to_col > col ? 1 : -1
-    row_direction = to_row > row ? 1 : -1
-    current_col = col + col_direction
-    current_row = row + row_direction
-    while (to_row - current_row).abs > 0 && (to_col - current_col).abs > 0
-      obstruction_array << [current_row, current_col]
-      current_col += col_direction
-      current_row += row_direction
-    end
-    Rails.logger.debug "Diagonal Move. Inspect #{obstruction_array.size} squares"
-    obstruction_array
-  end
-
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -10,7 +10,7 @@ class Piece < ApplicationRecord
     %w(Pawn Rook Knight Bishop Queen King)
   end
 
-  # Adds an STI type property to the JSON data, rails doesn't do this be default
+  # Adds an STI type property to the JSON data, rails doesn't do this by default
   def serializable_hash(options = nil)
     super.merge("type" => type)
   end
@@ -21,10 +21,9 @@ class Piece < ApplicationRecord
     from_row = row
     from_col = col
     update_attributes(row: to_row, col: to_col)
-    # create_move!(from_row, from_col)
+    create_move!(from_row, from_col)
+    true
   end
-
-
 
   private
 
@@ -34,7 +33,6 @@ class Piece < ApplicationRecord
     return false unless move_legal?(to_row, to_col)
     return false if move_obstructed?(to_row, to_col)
     return false if move_destination_obstructed?(to_row, to_col)
-
     true
   end
 
@@ -66,66 +64,73 @@ class Piece < ApplicationRecord
     end
 
     obstruction_array = []
-    col_direction = 0
-    row_direction = 0
-
     if row == to_row
-      col_direction = to_col > col ? 1 : -1
-      current_col = col + col_direction
-      while (to_col - current_col).abs > 0
-        obstruction_array << [row,current_col]
-        current_col += col_direction
-      end
-      Rails.logger.debug "Horizonal Move. Inspect #{obstruction_array.size} squares"
+      obstruction_array = move_obstructed_horizontal(to_col)
     elsif col == to_col
-      row_direction = to_row > row ? 1 : -1
-      current_row = row + row_direction
-      while (to_row - current_row).abs > 0
-        obstruction_array << [current_row,col]
-        current_row += row_direction
-      end
-      Rails.logger.debug "Vertical Move. Inspect #{obstruction_array.size} squares"
+      obstruction_array = move_obstructed_vertical(to_row)
     elsif (row - to_row).abs == (col - to_col).abs
-      col_direction = to_col > col ? 1 : -1
-      row_direction = to_row > row ? 1 : -1
-      current_col = col + col_direction
-      current_row = row + row_direction
-      while (to_row - current_row).abs > 0 && (to_col - current_col).abs > 0
-        obstruction_array << [current_row,current_col]
-        current_col += col_direction
-        current_row += row_direction
-      end
-      Rails.logger.debug "Diagonal Move. Inspect #{obstruction_array.size} squares"
+      obstruction_array = move_obstructed_diagonal(to_row, to_col)
     end
 
-    Rails.logger.debug ""
-    Rails.logger.debug "Iterate obstruction_array"
-
+    # Rails.logger.debug "Obstruction array contains #{obstruction_array.size} elements"
     return false if obstruction_array.empty?
     obstruction_array.each do |square|
-      if game.piece_at(square[0],square[1])
-        Rails.logger.debug "Obstructed Square at #{square[0]}, #{square[1]}"
-      end
-      return true if game.piece_at(square[0],square[1])
+      return true if game.piece_at(square[0], square[1])
     end
-    Rails.logger.debug "NO OBSTRUCTION"
+
     false
+  end
+
+  def move_obstructed_horizontal(to_col)
+    obstruction_array = []
+    col_direction = to_col > col ? 1 : -1
+    current_col = col + col_direction
+    while (to_col - current_col).abs > 0
+      obstruction_array << [row, current_col]
+      current_col += col_direction
+    end
+    Rails.logger.debug "Horizonal Move. Inspect #{obstruction_array.size} squares"
+    obstruction_array
+  end
+
+  def move_obstructed_vertical(to_row)
+    obstruction_array = []
+    row_direction = to_row > row ? 1 : -1
+    current_row = row + row_direction
+    while (to_row - current_row).abs > 0
+      obstruction_array << [current_row, col]
+      current_row += row_direction
+    end
+    Rails.logger.debug "Vertical Move. Inspect #{obstruction_array.size} squares"
+    obstruction_array
+  end
+
+  def move_obstructed_diagonal(to_row, to_col)
+    obstruction_array = []
+    col_direction = to_col > col ? 1 : -1
+    row_direction = to_row > row ? 1 : -1
+    current_col = col + col_direction
+    current_row = row + row_direction
+    while (to_row - current_row).abs > 0 && (to_col - current_col).abs > 0
+      obstruction_array << [current_row, current_col]
+      current_col += col_direction
+      current_row += row_direction
+    end
+    Rails.logger.debug "Diagonal Move. Inspect #{obstruction_array.size} squares"
+    obstruction_array
   end
 
   def move_destination_obstructed?(to_row, to_col)
     other_piece = game.piece_at(to_row, to_col)
     if other_piece
       side = "White"
-      if other_piece.is_black
-        side = "Black"
-      end
-      Rails.logger.debug "Destination NOT CLEAR. There is a #{other_piece.type} for side #{side} at destination."
+      side = "Black" unless other_piece.is_black
+      Rails.logger.debug "Destination NOT CLEAR. #{side} #{other_piece.type} at destination."
       if other_piece.user == user
-        Rails.logger.debug "DESTINATION CONTAINS SAME SIDE PIECE. ERROR"
+        Rails.logger.debug "   DESTINATION CONTAINS SAME SIDE PIECE. ERROR"
         true
       else
-        Rails.logger.debug "Destination contains opponent piece. capture possible."
-
+        Rails.logger.debug "   Destination contains opponent piece. capture possible."
         # call capture logic
         other_piece.update(is_captured: true)
         false
@@ -135,8 +140,6 @@ class Piece < ApplicationRecord
       false
     end
   end
-
-
 
   # moved capture piece methods to private - after verify that move to new square is valid
   def capture_piece(row, col)
@@ -154,7 +157,6 @@ class Piece < ApplicationRecord
   def captured?
     is_captured == true
   end
-
 
   def create_move!(from_row, from_col)
     last_move_number = game.moves.last ? game.moves.last.move_number : 0

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -17,13 +17,12 @@ class Piece < ApplicationRecord
 
   def move_to!(to_row, to_col)
     return false unless valid_move?(to_row, to_col)
-
+    # en passant capture won't work if the line below executes after updating coords
     capture_piece(to_row, to_col)
 
     from_row = row
     from_col = col
     update_attributes(row: to_row, col: to_col)
-
     create_move!(from_row, from_col)
   end
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -20,7 +20,7 @@ class Piece < ApplicationRecord
     from_row = row
     from_col = col
     update_attributes(row: to_row, col: to_col)
-    create_move!(from_row, from_col)
+    # create_move!(from_row, from_col)
   end
 
   def capture_piece(row, col)
@@ -40,8 +40,8 @@ class Piece < ApplicationRecord
   def valid_move?(to_row, to_col)
     return false if move_nil?(to_row, to_col)
     return false if move_out_of_bounds?(to_row, to_col)
+    return false if move_destination_ally?(to_row, to_col)
     return false unless move_legal?(to_row, to_col)
-    return false if move_destination_obstructed?(to_row, to_col)
     return false if move_obstructed?(to_row, to_col)
     true
   end
@@ -52,6 +52,11 @@ class Piece < ApplicationRecord
 
   def move_out_of_bounds?(to_row, to_col)
     to_row < 0 || to_row > 7 || to_col < 0 || to_col > 7
+  end
+
+  def move_destination_ally?(to_row, to_col)
+    Rails.logger.debug "MOVE DESTINATION ALLY at #{to_row},#{to_col}"
+    return true
   end
 
   def move_legal?(to_row, to_col)
@@ -66,9 +71,7 @@ class Piece < ApplicationRecord
     end
   end
 
-  def move_destination_obstructed?(_to_row, _to_col)
-    false
-  end
+
 
   def move_obstructed?(_to_row, _to_col)
     false

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -16,18 +16,18 @@ class Piece < ApplicationRecord
   end
 
   def move_to!(to_row, to_col)
-    logger.debug "piece model. move_to. did it change? destination: #{to_row},#{to_col}"
+    logger.debug "piece model. move_to! destination: #{to_row},#{to_col}"
 
     logger.debug "before call to valid_move?"
     return false unless valid_move?(to_row, to_col)
 
     capture_piece(to_row, to_col)
 
-    # from_row = row
-    # from_col = col
+    from_row = row
+    from_col = col
     update_attributes(row: to_row, col: to_col)
 
-    # create_move!(from_row, from_col)
+    create_move!(from_row, from_col)
   end
 
   def capture_piece(row, col)
@@ -55,19 +55,16 @@ class Piece < ApplicationRecord
   end
 
   def move_nil?(to_row, to_col)
-    Rails.logger.debug "MOVE NIL"
     row == to_row && col == to_col
   end
 
   def move_out_of_bounds?(to_row, to_col)
-    Rails.logger.debug "OUT OF BOUNDS"
     to_row < 0 || to_row > 7 || to_col < 0 || to_col > 7
   end
 
   def move_destination_ally?(to_row, to_col)
-    # puts ally_at(to_row, to_col).inspect
-    !!ally_at(to_row, to_col)   # will convert to true if returns object, false if returns false
-
+    ally = game.piece_at(to_row, to_col)
+    ally && ally.is_black == is_black ? true : false
   end
 
   def move_legal?(to_row, to_col)
@@ -113,11 +110,5 @@ class Piece < ApplicationRecord
   def enemy_at(check_row, check_col)
     enemy = game.piece_at(check_row, check_col)
     enemy if enemy && enemy.is_black != is_black
-  end
-
-  def ally_at(check_row, check_col)
-    ally = game.piece_at(check_row, check_col)
-    puts ally.inspect
-    ally if ally && ally.is_black == is_black
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -16,14 +16,16 @@ class Piece < ApplicationRecord
   end
 
   def move_to!(to_row, to_col)
-    logger.debug "piece model. move_to. destination: #{to_row},#{to_col}"
+    logger.debug "piece model. move_to. did it change? destination: #{to_row},#{to_col}"
 
     logger.debug "before call to valid_move?"
-    return unless valid_move?(to_row, to_col)
+    return false unless valid_move?(to_row, to_col)
+
+    capture_piece(to_row, to_col)
 
     # from_row = row
     # from_col = col
-    # update_attributes(row: to_row, col: to_col)
+    update_attributes(row: to_row, col: to_col)
 
     # create_move!(from_row, from_col)
   end
@@ -63,7 +65,9 @@ class Piece < ApplicationRecord
   end
 
   def move_destination_ally?(to_row, to_col)
-    true
+    # puts ally_at(to_row, to_col).inspect
+    !!ally_at(to_row, to_col)   # will convert to true if returns object, false if returns false
+
   end
 
   def move_legal?(to_row, to_col)
@@ -112,9 +116,8 @@ class Piece < ApplicationRecord
   end
 
   def ally_at(check_row, check_col)
-    logger.debug "method ally_at"
-     ally = game.piece_at(check_row, check_col)
-     return true if ally && ally.is_black == is_black
-     false
+    ally = game.piece_at(check_row, check_col)
+    puts ally.inspect
+    ally if ally && ally.is_black == is_black
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -45,6 +45,10 @@ class Piece < ApplicationRecord
     return false if move_nil?(to_row, to_col)
     return false if move_out_of_bounds?(to_row, to_col)
     return false if move_destination_ally?(to_row, to_col)
+
+    # until have Knight::move_legal?
+    return true if type == "Knight"
+
     return false unless move_legal?(to_row, to_col)
     return false if move_obstructed?(to_row, to_col)
     true
@@ -68,22 +72,16 @@ class Piece < ApplicationRecord
     # fail NotImplementedError 'Piece sub-class must implement #legal_move?'
     # Will remove comment and following code once all sub-classes are complete.
 
-    if type == "Knight"
-      true
-    else
-      row == to_row || col == to_col || (row - to_row).abs == (col - to_col).abs
-    end
+    row == to_row || col == to_col || (row - to_row).abs == (col - to_col).abs
   end
 
   def move_obstructed?(to_row, to_col)
     row_direction = to_row <=> row
     col_direction = to_col <=> col
 
-    # move one square off the current piece's square.
     current_row = row + row_direction
     current_col = col + col_direction
 
-    # continue until square before destination. NOT looking at the destination square
     until current_row == to_row && current_col == to_col
       return true if game.piece_at(current_row, current_col)
       current_row += row_direction

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -46,7 +46,7 @@ class Piece < ApplicationRecord
     return false if move_out_of_bounds?(to_row, to_col)
     return false if move_destination_ally?(to_row, to_col)
     return false unless move_legal?(to_row, to_col)
-    return false if move_obstructed?(to_row, to_col) && type != 'Knight'
+    return false if move_obstructed?(to_row, to_col)
     true
   end
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -16,10 +16,19 @@ class Piece < ApplicationRecord
   end
 
   def move_to!(to_row, to_col)
-    return unless valid_move?(to_row, to_col)
-    from_row = row
-    from_col = col
-    update_attributes(row: to_row, col: to_col)
+    Rails.logger.debug "MOVE TO MOVE TO MOVE TO MOVE TO "
+
+    if valid_move?(to_row, to_col)
+      logger.debug "VALID MOVE returned true"
+    else
+      logger.debug "VALID MOVE returned false"
+    end
+
+    # from_row = row
+    # from_col = col
+    # update_attributes(row: to_row, col: to_col)
+
+
     # create_move!(from_row, from_col)
   end
 
@@ -38,25 +47,28 @@ class Piece < ApplicationRecord
   private
 
   def valid_move?(to_row, to_col)
+    Rails.logger.debug "VALID MOVE updated code"
     return false if move_nil?(to_row, to_col)
     return false if move_out_of_bounds?(to_row, to_col)
     return false if move_destination_ally?(to_row, to_col)
     return false unless move_legal?(to_row, to_col)
-    return false if move_obstructed?(to_row, to_col)
+    # return false if move_obstructed?(to_row, to_col)
     true
   end
 
   def move_nil?(to_row, to_col)
+    Rails.logger.debug "MOVE NIL"
     row == to_row && col == to_col
   end
 
   def move_out_of_bounds?(to_row, to_col)
+    Rails.logger.debug "OUT OF BOUNDS"
     to_row < 0 || to_row > 7 || to_col < 0 || to_col > 7
   end
 
   def move_destination_ally?(to_row, to_col)
-    Rails.logger.debug "MOVE DESTINATION ALLY at #{to_row},#{to_col}"
-    return true
+    Rails.logger.debug "DESTINATION ALLY"
+    ally_at(to_row, to_col)
   end
 
   def move_legal?(to_row, to_col)
@@ -112,6 +124,12 @@ class Piece < ApplicationRecord
   def enemy_at(check_row, check_col)
     enemy = game.piece_at(check_row, check_col)
     enemy if enemy && enemy.is_black != is_black
+  end
+
+  def ally_at(check_row, check_col)
+    ally = game.piece_at(check_row, check_col)
+    ally if ally && ally.is_black == is_black
+  end
 
   def move_obstructed_horizontal(to_col)
     obstruction_array = []

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -16,17 +16,14 @@ class Piece < ApplicationRecord
   end
 
   def move_to!(to_row, to_col)
-    Rails.logger.debug "MOVE TO MOVE TO MOVE TO MOVE TO "
+    logger.debug "piece model. move_to. destination: #{to_row},#{to_col}"
 
-    if valid_move?(to_row, to_col)
-      logger.debug "VALID MOVE returned true"
-    else
-      logger.debug "VALID MOVE returned false"
-    end
+    logger.debug "before call to valid_move?"
+    return unless valid_move?(to_row, to_col)
 
     # from_row = row
     # from_col = col
-    update_attributes(row: to_row, col: to_col)
+    # update_attributes(row: to_row, col: to_col)
 
     # create_move!(from_row, from_col)
   end
@@ -46,7 +43,7 @@ class Piece < ApplicationRecord
   private
 
   def valid_move?(to_row, to_col)
-    Rails.logger.debug "VALID MOVE updated code"
+    logger.debug "inside valid_move"
     return false if move_nil?(to_row, to_col)
     return false if move_out_of_bounds?(to_row, to_col)
     return false if move_destination_ally?(to_row, to_col)
@@ -66,8 +63,7 @@ class Piece < ApplicationRecord
   end
 
   def move_destination_ally?(to_row, to_col)
-    Rails.logger.debug "DESTINATION ALLY"
-    ally_at(to_row, to_col)
+    true
   end
 
   def move_legal?(to_row, to_col)
@@ -91,7 +87,7 @@ class Piece < ApplicationRecord
     current_col = col + col_direction
 
     # continue until square before destination. NOT looking at the destination square
-    until current_row == to_row - row_direction && current_col == to_col - col_direction
+    until current_row == to_row && current_col == to_col
       return true if game.piece_at(current_row, current_col)
       current_row += row_direction
       current_col += col_direction
@@ -116,7 +112,9 @@ class Piece < ApplicationRecord
   end
 
   def ally_at(check_row, check_col)
-    ally = game.piece_at(check_row, check_col)
-    ally if ally && ally.is_black == is_black
+    logger.debug "method ally_at"
+     ally = game.piece_at(check_row, check_col)
+     return true if ally && ally.is_black == is_black
+     false
   end
 end

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -1,5 +1,5 @@
 class Rook < Piece
-  def valid_move?(to_row, to_col)
+  def move_legal?(to_row, to_col)
     return true if col == to_col || row == to_row
     false
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,5 +52,5 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,5 +52,5 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::FileUpdateChecker
+  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -32,9 +32,7 @@ RSpec.describe Piece, type: :model do
 
     it "should update row and col attributes" do
       piece = @game.pieces.create(row: FROM_ROW, col: FROM_COL, user: @user)
-      puts piece.inspect
       piece.move_to!(7, FROM_COL)
-      puts piece.inspect
       expect(piece.row).to eq(7)
       expect(piece.col).to eq(FROM_COL)
     end
@@ -49,8 +47,8 @@ RSpec.describe Piece, type: :model do
       expect(move.game_id).to eq(@game.id)
     end
 
-    # MeO tests for move_to! - test private valid_move? and its called methods
-    # add private valid_move tests
+    # MeO tests supporting move_to! - test private valid_move? and its called methods
+    # rubocop:disable UselessAssignment
     describe "tests private valid_move?" do
       it "with a nil move" do
         piece = @game.pieces.create(row: FROM_ROW, col: FROM_COL, user: @user)
@@ -65,7 +63,7 @@ RSpec.describe Piece, type: :model do
         piece2 = @game.pieces.create(row: MOVE_ROW - 4, col: MOVE_COL, is_black: true, user: @user)
         expect(piece1.send(:valid_move?, MOVE_ROW - 4, MOVE_COL)).to be false
       end
-      it "with an obstructed path" do
+      it "with an obstructed diagonal path" do
         piece1 = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL, user: @user)
         piece2 = @game.pieces.create(row: MOVE_ROW - 2, col: MOVE_COL + 2, user: @user)
         expect(piece1.send(:valid_move?, MOVE_ROW - 4, MOVE_COL + 4)).to be false
@@ -97,7 +95,7 @@ RSpec.describe Piece, type: :model do
     describe "tests private move_destination_ally?" do
       it "with an empty destination" do
         piece = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL, is_black: true, user: @user)
-        expect(piece.send(:move_destination_ally?,MOVE_ROW - 4, MOVE_COL)).to be false
+        expect(piece.send(:move_destination_ally?, MOVE_ROW - 4, MOVE_COL)).to be false
       end
       it "with an enemy-occupied destination" do
         piece1 = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL, is_black: true, user: @user)
@@ -111,40 +109,38 @@ RSpec.describe Piece, type: :model do
       end
     end
 
-    describe "move_obstructed?" do
-    it "with horizontal move and no obstruction" do
-      piece = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL, user: @user)
-      expect(piece.send(:move_obstructed?, MOVE_ROW - 4, MOVE_COL)).to be false
-    end
-    it "with horizontal move and obstruction" do
-      piece1 = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL, user: @user)
-      piece2 = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL + 2, user: @user)
-      expect(piece1.send(:move_obstructed?, MOVE_ROW, MOVE_COL + 6)).to be true
-    end
+    describe "tests private move_obstructed?" do
+      it "with horizontal move and no obstruction" do
+        piece = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL, user: @user)
+        expect(piece.send(:move_obstructed?, MOVE_ROW - 4, MOVE_COL)).to be false
+      end
+      it "with horizontal move and obstruction" do
+        piece1 = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL, user: @user)
+        piece2 = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL + 2, user: @user)
+        expect(piece1.send(:move_obstructed?, MOVE_ROW, MOVE_COL + 6)).to be true
+      end
 
-    it "with vertical move and no obstruction" do
-      piece = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL, user: @user)
-      expect(piece.send(:move_obstructed?, MOVE_ROW - 4, MOVE_COL)).to be false
-    end
-    it "with vertical move and obstruction" do
-      piece1 = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL, user: @user)
-      piece2 = @game.pieces.create(row: MOVE_ROW - 2, col: MOVE_COL, user: @user)
-      expect(piece1.send(:move_obstructed?, MOVE_ROW - 4, MOVE_COL)).to be true
-    end
+      it "with vertical move and no obstruction" do
+        piece = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL, user: @user)
+        expect(piece.send(:move_obstructed?, MOVE_ROW - 4, MOVE_COL)).to be false
+      end
+      it "with vertical move and obstruction" do
+        piece1 = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL, user: @user)
+        piece2 = @game.pieces.create(row: MOVE_ROW - 2, col: MOVE_COL, user: @user)
+        expect(piece1.send(:move_obstructed?, MOVE_ROW - 4, MOVE_COL)).to be true
+      end
 
-    it "with diagonal move and no obstruction" do
-      piece = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL, user: @user)
-      expect(piece.send(:move_obstructed?, MOVE_ROW - 4, MOVE_COL + 4)).to be false
-    end
-    it "with diagonal move and obstruction" do
-      piece1 = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL, user: @user)
-      piece2 = @game.pieces.create(row: MOVE_ROW - 2, col: MOVE_COL + 2, user: @user)
-      expect(piece1.send(:move_obstructed?, MOVE_ROW - 4, MOVE_COL + 4)).to be true
+      it "with diagonal move and no obstruction" do
+        piece = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL, user: @user)
+        expect(piece.send(:move_obstructed?, MOVE_ROW - 4, MOVE_COL + 4)).to be false
+      end
+      it "with diagonal move and obstruction" do
+        piece1 = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL, user: @user)
+        piece2 = @game.pieces.create(row: MOVE_ROW - 2, col: MOVE_COL + 2, user: @user)
+        expect(piece1.send(:move_obstructed?, MOVE_ROW - 4, MOVE_COL + 4)).to be true
+      end
     end
   end
-
-end
-
 
   describe "#capture_piece" do
     before(:all) do

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -8,14 +8,15 @@ RSpec.describe Piece, type: :model do
   end
 
   describe "#move_to!" do
+    @user = User.create(
+      email: 'foobar@foobar.com',
+      screen_name: 'foobar',
+      password: 'foobar',
+      password_confirmation: 'foobar'
+    )
+    @game = @user.games.create(white_player_id: @user.id)
+
     before(:all) do
-      @user = User.create(
-        email: 'foobar@foobar.com',
-        screen_name: 'foobar',
-        password: 'foobar',
-        password_confirmation: 'foobar'
-      )
-      @game = @user.games.create(white_player_id: @user.id)
       FROM_ROW = 3
       FROM_COL = 2
       MOVE_ROW = 6

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -8,19 +8,19 @@ RSpec.describe Piece, type: :model do
   end
 
   describe "#move_to!" do
-    @user = User.create(
-      email: 'foobar@foobar.com',
-      screen_name: 'foobar',
-      password: 'foobar',
-      password_confirmation: 'foobar'
-    )
-    @game = @user.games.create(white_player_id: @user.id)
+    FROM_ROW = 3
+    FROM_COL = 2
+    MOVE_ROW = 6
+    MOVE_COL = 1
 
     before(:all) do
-      FROM_ROW = 3
-      FROM_COL = 2
-      MOVE_ROW = 6
-      MOVE_COL = 1
+      @user = User.create(
+        email: 'foobar@foobar.com',
+        screen_name: 'foobar',
+        password: 'foobar',
+        password_confirmation: 'foobar'
+      )
+      @game = @user.games.create(white_player_id: @user.id)
     end
 
     after(:all) do

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -31,338 +31,128 @@ RSpec.describe Piece, type: :model do
     end
 
     it "should update row and col attributes" do
-      piece = @game.pieces.create(
-        row: 0, col: 0, user: @user
-      )
-      piece.move_to!(7, 7)
-
+      piece = @game.pieces.create(row: FROM_ROW, col: FROM_COL)
+      piece.move_to!(7, FROM_COL)
       expect(piece.row).to eq(7)
-      expect(piece.col).to eq(7)
+      expect(piece.col).to eq(FROM_COL)
     end
 
     it "should create a new move" do
-      piece = @game.pieces.create(
-        row: 0, col: 0, user: @user
-      )
-      piece.move_to!(7, 7)
+      piece = @game.pieces.create(row: FROM_ROW, col: FROM_COL)
+      piece.move_to!(7, FROM_COL)
       move = piece.moves.last
-
       expect(move.move_number).to eq(1)
-      expect(move.from_position).to eq([0, 0])
-      expect(move.to_position).to eq([7, 7])
+      expect(move.from_position).to eq([FROM_ROW, FROM_COL])
+      expect(move.to_position).to eq([7, FROM_COL])
       expect(move.game_id).to eq(@game.id)
     end
-
+=begin
     # MeO tests for move_to! - test private valid_move? and its called methods
-
-<<<<<<< HEAD
-    describe "#move_nil?" do
-      it "tests private method move_nil? with a nil move" do
-        piece = @game.pieces.create(
-          row: FROM_ROW, col: FROM_COL, user: @user
-        )
+    describe "tests private valid_move?" do
+      it "with a nil move" do
+        piece = @game.pieces.create(row: FROM_ROW, col: FROM_COL)
+        expect(piece.send(:valid_move?, FROM_ROW, FROM_COL)).to be false
+      end
+      it "with an off-board move" do
+        piece = @game.pieces.create(row: FROM_ROW, col: FROM_COL)
+        expect(piece.send(:valid_move?, FROM_ROW, 8)).to be false
+      end
+      it "with an ally at destination" do
+        piece1 = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL, is_black: true)
+        piece2 = @game.pieces.create(row: MOVE_ROW - 3, col: MOVE_COL, is_black: true)
+        expect(piece1.send(:valid_move?, MOVE_ROW - 3, MOVE_COL)).to be false
+      end
+      # add valid_move? with obstructed moves: horizontal, vertical, diagonal
+      it "with an obstructed horizontal move" do
+        piece1 = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL)
+        piece2 = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL + 2)
+        expect(piece1.send(:valid_move?, MOVE_ROW, MOVE_COL + 6)).to be false
+      end
+      it "with an obstructed vertical move" do
+        piece1 = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL)
+        piece2 = @game.pieces.create(row: MOVE_ROW - 2, col: MOVE_COL)
+        expect(piece1.send(:valid_move?, MOVE_ROW - 4, MOVE_COL)).to be false
+      end
+      it "with an obstructed diagonal move" do
+        piece1 = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL)
+        piece2 = @game.pieces.create(row: MOVE_ROW - 2, col: MOVE_COL + 2)
+        expect(piece1.send(:valid_move?, MOVE_ROW - 4, MOVE_COL + 4)).to be false
+      end
+    end
+=end
+    describe "tests private #move_nil?" do
+      it "with a nil move" do
+        piece = @game.pieces.create(row: FROM_ROW, col: FROM_COL)
         expect(piece.send(:move_nil?, FROM_ROW, FROM_COL)).to be true
       end
-
-      it "tests private method move_nil? with a non-nil move" do
-        piece = @game.pieces.create(
-          row: FROM_ROW, col: FROM_COL, user: @user
-        )
+      it "with a non-nil move" do
+        piece = @game.pieces.create(row: FROM_ROW, col: FROM_COL)
         expect(piece.send(:move_nil?, 7, 7)).to be false
       end
     end
 
-    describe "#move_out_bounds?" do
-      it "tests private method move_out_of_bounds? with an off-board move" do
-        piece = @game.pieces.create(
-          row: FROM_ROW, col: FROM_COL, user: @user
-        )
+    describe "tests private move_out_bounds?" do
+      it "with an off-board move" do
+        piece = @game.pieces.create(row: FROM_ROW, col: FROM_COL)
         expect(piece.send(:move_out_of_bounds?, FROM_ROW, 8)).to be true
       end
-
-      it "tests private method move_out_of_bounds? with an on-board move" do
-        piece = @game.pieces.create(
-          row: FROM_ROW, col: FROM_COL, user: @user
-        )
+      it "with an on-board move" do
+        piece = @game.pieces.create(row: FROM_ROW, col: FROM_COL)
         expect(piece.send(:move_out_of_bounds?, FROM_ROW + 1, FROM_COL + 1)).to be false
       end
     end
 
-    describe "#valid_move?" do
-      it "tests private method valid_move? with a nil move" do
-        piece = @game.pieces.create(
-          row: FROM_ROW, col: FROM_COL, user: @user
-        )
-        expect(piece.send(:valid_move?, FROM_ROW, FROM_COL)).to be false
+    describe "tests private move_destination_ally?" do
+      it "with an empty destination" do
+        piece = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL, is_black: true)
+        expect(piece.send(:move_destination_ally?,MOVE_ROW - 4, MOVE_COL)).to be false
       end
-
-      it "tests private method valid_move? with an out of bounds move" do
-        piece = @game.pieces.create(
-          row: FROM_ROW, col: FROM_COL, user: @user
-        )
-        expect(piece.send(:valid_move?, FROM_ROW, 8)).to be false
+      it "with an enemy-occupied destination" do
+        piece1 = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL, is_black: true)
+        piece2 = @game.pieces.create(row: MOVE_ROW - 4, col: MOVE_COL, is_black: false)
+        expect(piece1.send(:move_destination_ally?, MOVE_ROW - 4, MOVE_COL)).to be false
+      end
+      it "with an ally-occupied destination" do
+        piece1 = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL, is_black: true)
+        piece2 = @game.pieces.create(row: MOVE_ROW - 4, col: MOVE_COL, is_black: true)
+        expect(piece1.send(:move_destination_ally?, MOVE_ROW - 4, MOVE_COL)).to be true
       end
     end
 
-    # This should be integrated into the '#move_to!' group
-=======
-    # private method move_nil?
-    it "tests move_nil? with a nil move" do
-      piece = @game.pieces.create(
-        row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
-      )
-      expect(piece.send(:move_nil?, FROM_ROW, FROM_COL)).to be true
-    end
-    it "tests move_nil? with a valid move" do
-      piece = @game.pieces.create(
-        row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
-      )
-      expect(piece.send(:move_nil?, 7, 7)).to be false
-    end
-
-    # private method move_out_bounds
-    it "tests move_out_of_bounds? with an off-board move" do
-      piece = @game.pieces.create(
-        row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
-      )
-      expect(piece.send(:move_out_of_bounds?, FROM_ROW, 8)).to be true
-    end
-    it "tests move_out_of_bounds? with an on-board move" do
-      piece = @game.pieces.create(
-        row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
-      )
-      expect(piece.send(:move_out_of_bounds?, FROM_ROW + 1, FROM_COL + 1)).to be false
-    end
-
-    # private method move_destination_same_side?
-    it "tests move_destination_same_side? with empty destination square" do
-      piece = @game.pieces.create(
-        row: MOVE_ROW, col: MOVE_COL, is_captured: false, user: @user
-      )
-      expect(piece.send(:move_destination_same_side?, MOVE_ROW - 4, MOVE_COL)).to be nil
-    end
-
-    it "tests move_destination_same_side? with same side piece at destination" do
-      piece1 = @game.pieces.create(
-        row: MOVE_ROW, col: MOVE_COL, is_captured: false, is_black: true, user: @user
-      )
-      piece2 = @game.pieces.create(
-        row: MOVE_ROW, col: MOVE_COL + 4, is_captured: false, is_black: true, user: @user
-      )
-      expect(piece1.send(:move_destination_same_side?, MOVE_ROW, MOVE_COL + 4)).to be true
-    end
-
-    it "tests move_destination_same_side? with other side piece at destination" do
-      piece1 = @game.pieces.create(
-        row: MOVE_ROW, col: MOVE_COL, is_captured: false, is_black: true, user: @user
-      )
-      piece2 = @game.pieces.create(
-        row: MOVE_ROW, col: MOVE_COL + 4, is_captured: false, is_black: false, user: @user
-      )
-      expect(piece1.send(:move_destination_same_side?, MOVE_ROW, MOVE_COL + 4)).to be false
-    end
-
-    # private method move_obstructed
+    describe "move_obstructed?" do
     it "tests move_obstructed with horizontal move and no obstruction" do
-      piece = @game.pieces.create(
-        row: MOVE_ROW, col: MOVE_COL, is_captured: false, user: @user
-      )
-      expect(piece.send(:move_obstructed?, MOVE_ROW, MOVE_COL + 6)).to be false
+      piece = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL)
+      expect(piece.send(:move_obstructed?, MOVE_ROW - 4, MOVE_COL)).to be false
     end
-
     it "tests move_obstructed with horizontal move and obstruction" do
-      piece1 = @game.pieces.create(
-        row: MOVE_ROW, col: MOVE_COL, is_captured: false, user: @user
-      )
-      piece2 = @game.pieces.create(
-        row: MOVE_ROW, col: MOVE_COL + 2, is_captured: false, user: @user
-      )
+      piece1 = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL)
+      piece2 = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL + 2)
       expect(piece1.send(:move_obstructed?, MOVE_ROW, MOVE_COL + 6)).to be true
     end
 
     it "tests move_obstructed with vertical move and no obstruction" do
-      piece = @game.pieces.create(
-        row: MOVE_ROW, col: MOVE_COL, is_captured: false, user: @user
-      )
+      piece = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL)
       expect(piece.send(:move_obstructed?, MOVE_ROW - 4, MOVE_COL)).to be false
     end
-
     it "tests move_obstructed with vertical move and obstruction" do
-      piece1 = @game.pieces.create(
-        row: MOVE_ROW, col: MOVE_COL, is_captured: false, user: @user
-      )
-      piece2 = @game.pieces.create(
-        row: MOVE_ROW - 2, col: MOVE_COL, is_captured: false, user: @user
-      )
+      piece1 = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL)
+      piece2 = @game.pieces.create(row: MOVE_ROW - 2, col: MOVE_COL)
       expect(piece1.send(:move_obstructed?, MOVE_ROW - 4, MOVE_COL)).to be true
     end
 
     it "tests move_obstructed with diagonal move and no obstruction" do
-      piece = @game.pieces.create(
-        row: MOVE_ROW, col: MOVE_COL, is_captured: false, user: @user
-      )
+      piece = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL)
       expect(piece.send(:move_obstructed?, MOVE_ROW - 4, MOVE_COL + 4)).to be false
     end
-
     it "tests move_obstructed with diagonal move and obstruction" do
-      piece1 = @game.pieces.create(
-        row: MOVE_ROW, col: MOVE_COL, is_captured: false, user: @user
-      )
-      piece2 = @game.pieces.create(
-        row: MOVE_ROW - 2, col: MOVE_COL + 2, is_captured: false, user: @user
-      )
+      piece1 = @game.pieces.create(row: MOVE_ROW, col: MOVE_COL)
+      piece2 = @game.pieces.create(row: MOVE_ROW - 2, col: MOVE_COL + 2)
       expect(piece1.send(:move_obstructed?, MOVE_ROW - 4, MOVE_COL + 4)).to be true
     end
-
-    # Private method valid_move?
-    it "tests valid_move? with a nil move" do
-      piece = @game.pieces.create(
-        row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
-      )
-      expect(piece.send(:valid_move?, FROM_ROW, FROM_COL)).to be false
-    end
-
-    it "tests valid_move? with an out of bounds move" do
-      piece = @game.pieces.create(
-        row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
-      )
-      expect(piece.send(:valid_move?, FROM_ROW, 8)).to be false
-    end
-
-    it "tests valid_move? with same side piece at destination" do
-      piece1 = @game.pieces.create(
-        row: FROM_ROW, col: FROM_COL, is_captured: false, is_black: true, user: @user
-      )
-      piece2 = @game.pieces.create(
-        row: FROM_ROW + 3, col: FROM_COL + 3, is_captured: false, is_black: true, user: @user
-      )
-      expect(piece1.send(:valid_move?, FROM_ROW + 3, FROM_ROW + 3)).to be false
-    end
-
-    it "tests method valid_move? with a diagonal obstructed move" do
-      row = 6
-      col = 1
-      piece1 = @game.pieces.create(
-        row: row, col: col, is_captured: false, user: @user
-      )
-      piece2 = @game.pieces.create(
-        row: row - 2, col: col + 2, is_captured: false, user: @user
-      )
-      expect(piece1.send(:valid_move?, row - 4, col + 4)).to be false
-    end
-
->>>>>>> origin/move_obstructed
-    # move_to! with an out-of-bounds move
-    it "should not move the piece out of bounds" do
-      to_col = 8
-      piece = @game.pieces.create(
-        row: FROM_ROW, col: FROM_COL, user: @user
-      )
-      piece.move_to!(FROM_ROW, to_col)
-      expect(piece.row).to eq(FROM_ROW)
-      expect(piece.col).to eq(FROM_COL)
-    end
-
-<<<<<<< HEAD
-    # remove after all piece subclass tests complete
-    describe "#move_legal?" do
-      it "should not move the piece due to illegal move" do
-        piece = @game.pieces.create(
-          row: FROM_ROW, col: FROM_COL, user: @user
-        )
-        piece.move_to!(FROM_ROW + 2, FROM_COL + 1)
-        expect(piece.row).to eq(FROM_ROW)
-        expect(piece.col).to eq(FROM_COL)
-      end
-
-      it "should move the piece: horizonal move" do
-        to_col = 7
-        piece = @game.pieces.create(
-          row: FROM_ROW, col: FROM_COL, user: @user
-        )
-        piece.move_to!(FROM_ROW, to_col)
-        expect(piece.row).to eq(FROM_ROW)
-        expect(piece.col).to eq(to_col)
-      end
-
-      it "should move the piece: vertical move" do
-        to_row = 7
-        piece = @game.pieces.create(
-          row: FROM_ROW, col: FROM_COL, user: @user
-        )
-        piece.move_to!(to_row, FROM_COL)
-        expect(piece.row).to eq(to_row)
-        expect(piece.col).to eq(FROM_COL)
-      end
-
-      it "should move the piece: diagonal move" do
-        to_row = 6
-        to_col = 5
-        piece = @game.pieces.create(
-          row: FROM_ROW, col: FROM_COL, user: @user
-        )
-        piece.move_to!(to_row, to_col)
-        expect(piece.row).to eq(to_row)
-        expect(piece.col).to eq(to_col)
-      end
-=======
-    # move_to! with an obstructed horizontal move
-    it "should not move the piece because of horizontal obstruction" do
-      row = 4
-      col = 1
-      piece1 = @game.pieces.create(
-        row: row, col: col, is_captured: false, user: @user
-      )
-      piece2 = @game.pieces.create(
-        row: row, col: col + 2, is_captured: false, user: @user
-      )
-      piece1.move_to!(row, col + 4)
-      expect(piece1.row).to eq(row)
-      expect(piece1.col).to eq(col)
-    end
-
-    # remove test after all piece subclass tests complete
-    it "should not move the piece due to illegal move" do
-      piece = @game.pieces.create(
-        row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
-      )
-      piece.move_to!(FROM_ROW + 2, FROM_COL + 1)
-      expect(piece.row).to eq(FROM_ROW)
-      expect(piece.col).to eq(FROM_COL)
-    end
-    # remove test after all piece subclass tests complete
-    it "should move the piece: horizonal move" do
-      to_col = 7
-      piece = @game.pieces.create(
-        row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
-      )
-      piece.move_to!(FROM_ROW, to_col)
-      expect(piece.row).to eq(FROM_ROW)
-      expect(piece.col).to eq(to_col)
-    end
-    # remove test after all piece subclass tests complete
-    it "should move the piece: vertical move" do
-      to_row = 7
-      piece = @game.pieces.create(
-        row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
-      )
-      piece.move_to!(to_row, FROM_COL)
-      expect(piece.row).to eq(to_row)
-      expect(piece.col).to eq(FROM_COL)
-    end
-    # remove test after all piece subclass tests complete
-    it "should move the piece: diagonal move" do
-      to_row = 6
-      to_col = 5
-      piece = @game.pieces.create(
-        row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
-      )
-      piece.move_to!(to_row, to_col)
-      expect(piece.row).to eq(to_row)
-      expect(piece.col).to eq(to_col)
->>>>>>> origin/move_obstructed
-    end
   end
+
+end
+
 
   describe "#capture_piece" do
     before(:all) do

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe Piece, type: :model do
       )
 
       @game = @user.games.create(white_player_id: @user)
+      FROM_ROW = 3
+      FROM_COL = 2
+      MOVE_ROW = 6
+      MOVE_COL = 1
     end
 
     before(:each) do
@@ -50,51 +54,151 @@ RSpec.describe Piece, type: :model do
       expect(move.game_id).to eq(@game.id)
     end
 
-    # MeO tests for move_to! - test valid_move? and its called methods
-    FROM_ROW = 3
-    FROM_COL = 2
+    # MeO tests for move_to! - test private valid_move? and its called methods
 
-    # PRIVATE method move_nil?
-    it "tests private method move_nil? with a nil move" do
+    # private method move_nil?
+    it "tests move_nil? with a nil move" do
       piece = @game.pieces.create(
         row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
       )
       expect(piece.send(:move_nil?, FROM_ROW, FROM_COL)).to be true
     end
-    it "tests private method move_nil? with a non-nil move" do
+    it "tests move_nil? with a valid move" do
       piece = @game.pieces.create(
         row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
       )
       expect(piece.send(:move_nil?, 7, 7)).to be false
     end
 
-    # PRIVATE method move_out_bounds
-    it "tests private method move_out_of_bounds? with an off-board move" do
+    # private method move_out_bounds
+    it "tests move_out_of_bounds? with an off-board move" do
       piece = @game.pieces.create(
         row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
       )
       expect(piece.send(:move_out_of_bounds?, FROM_ROW, 8)).to be true
     end
-    it "tests private method move_out_of_bounds? with an on-board move" do
+    it "tests move_out_of_bounds? with an on-board move" do
       piece = @game.pieces.create(
         row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
       )
       expect(piece.send(:move_out_of_bounds?, FROM_ROW + 1, FROM_COL + 1)).to be false
     end
 
+    # private method move_destination_same_side?
+    it "tests move_destination_same_side? with empty destination square" do
+      piece = @game.pieces.create(
+        row: MOVE_ROW, col: MOVE_COL, is_captured: false, user: @user
+      )
+      expect(piece.send(:move_destination_same_side?, MOVE_ROW - 4, MOVE_COL)).to be nil
+    end
+
+    it "tests move_destination_same_side? with same side piece at destination" do
+      piece1 = @game.pieces.create(
+        row: MOVE_ROW, col: MOVE_COL, is_captured: false, is_black: true, user: @user
+      )
+      piece2 = @game.pieces.create(
+        row: MOVE_ROW, col: MOVE_COL + 4, is_captured: false, is_black: true, user: @user
+      )
+      expect(piece1.send(:move_destination_same_side?, MOVE_ROW, MOVE_COL + 4)).to be true
+    end
+
+    it "tests move_destination_same_side? with other side piece at destination" do
+      piece1 = @game.pieces.create(
+        row: MOVE_ROW, col: MOVE_COL, is_captured: false, is_black: true, user: @user
+      )
+      piece2 = @game.pieces.create(
+        row: MOVE_ROW, col: MOVE_COL + 4, is_captured: false, is_black: false, user: @user
+      )
+      expect(piece1.send(:move_destination_same_side?, MOVE_ROW, MOVE_COL + 4)).to be false
+    end
+
+    # private method move_obstructed
+    it "tests move_obstructed with horizontal move and no obstruction" do
+      piece = @game.pieces.create(
+        row: MOVE_ROW, col: MOVE_COL, is_captured: false, user: @user
+      )
+      expect(piece.send(:move_obstructed?, MOVE_ROW, MOVE_COL + 6)).to be false
+    end
+
+    it "tests move_obstructed with horizontal move and obstruction" do
+      piece1 = @game.pieces.create(
+        row: MOVE_ROW, col: MOVE_COL, is_captured: false, user: @user
+      )
+      piece2 = @game.pieces.create(
+        row: MOVE_ROW, col: MOVE_COL + 2, is_captured: false, user: @user
+      )
+      expect(piece1.send(:move_obstructed?, MOVE_ROW, MOVE_COL + 6)).to be true
+    end
+
+    it "tests move_obstructed with vertical move and no obstruction" do
+      piece = @game.pieces.create(
+        row: MOVE_ROW, col: MOVE_COL, is_captured: false, user: @user
+      )
+      expect(piece.send(:move_obstructed?, MOVE_ROW - 4, MOVE_COL)).to be false
+    end
+
+    it "tests move_obstructed with vertical move and obstruction" do
+      piece1 = @game.pieces.create(
+        row: MOVE_ROW, col: MOVE_COL, is_captured: false, user: @user
+      )
+      piece2 = @game.pieces.create(
+        row: MOVE_ROW - 2, col: MOVE_COL, is_captured: false, user: @user
+      )
+      expect(piece1.send(:move_obstructed?, MOVE_ROW - 4, MOVE_COL)).to be true
+    end
+
+    it "tests move_obstructed with diagonal move and no obstruction" do
+      piece = @game.pieces.create(
+        row: MOVE_ROW, col: MOVE_COL, is_captured: false, user: @user
+      )
+      expect(piece.send(:move_obstructed?, MOVE_ROW - 4, MOVE_COL + 4)).to be false
+    end
+
+    it "tests move_obstructed with diagonal move and obstruction" do
+      piece1 = @game.pieces.create(
+        row: MOVE_ROW, col: MOVE_COL, is_captured: false, user: @user
+      )
+      piece2 = @game.pieces.create(
+        row: MOVE_ROW - 2, col: MOVE_COL + 2, is_captured: false, user: @user
+      )
+      expect(piece1.send(:move_obstructed?, MOVE_ROW - 4, MOVE_COL + 4)).to be true
+    end
+
     # Private method valid_move?
-    it "tests private method valid_move? with a nil move" do
+    it "tests valid_move? with a nil move" do
       piece = @game.pieces.create(
         row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
       )
       expect(piece.send(:valid_move?, FROM_ROW, FROM_COL)).to be false
     end
 
-    it "tests private method valid_move? with an out of bounds move" do
+    it "tests valid_move? with an out of bounds move" do
       piece = @game.pieces.create(
         row: FROM_ROW, col: FROM_COL, is_captured: false, user: @user
       )
       expect(piece.send(:valid_move?, FROM_ROW, 8)).to be false
+    end
+
+    it "tests valid_move? with same side piece at destination" do
+      piece1 = @game.pieces.create(
+        row: FROM_ROW, col: FROM_COL, is_captured: false, is_black: true, user: @user
+      )
+      piece2 = @game.pieces.create(
+        row: FROM_ROW + 3, col: FROM_COL + 3, is_captured: false, is_black: true, user: @user
+      )
+      expect(piece1.send(:valid_move?, FROM_ROW + 3, FROM_ROW + 3)).to be false
+    end
+
+    it "tests method valid_move? with a diagonal obstructed move" do
+      row = 6
+      col = 1
+      piece1 = @game.pieces.create(
+        row: row, col: col, is_captured: false, user: @user
+      )
+      piece2 = @game.pieces.create(
+        row: row - 2, col: col + 2, is_captured: false, user: @user
+      )
+      expect(piece1.send(:valid_move?, row - 4, col + 4)).to be false
     end
 
     # move_to! with an out-of-bounds move
@@ -106,6 +210,21 @@ RSpec.describe Piece, type: :model do
       piece.move_to!(FROM_ROW, to_col)
       expect(piece.row).to eq(FROM_ROW)
       expect(piece.col).to eq(FROM_COL)
+    end
+
+    # move_to! with an obstructed horizontal move
+    it "should not move the piece because of horizontal obstruction" do
+      row = 4
+      col = 1
+      piece1 = @game.pieces.create(
+        row: row, col: col, is_captured: false, user: @user
+      )
+      piece2 = @game.pieces.create(
+        row: row, col: col + 2, is_captured: false, user: @user
+      )
+      piece1.move_to!(row, col + 4)
+      expect(piece1.row).to eq(row)
+      expect(piece1.col).to eq(col)
     end
 
     # remove test after all piece subclass tests complete

--- a/spec/models/rook_spec.rb
+++ b/spec/models/rook_spec.rb
@@ -4,15 +4,15 @@ RSpec.describe Rook, type: :model do
     let(:rook) { Rook.create(row: 0, col: 1) }
 
     it "should allow legal vertical moves" do
-      expect(rook.valid_move?(1, 1)).to be true
+      expect(rook.move_legal?(1, 1)).to be true
     end
 
     it "should allow legal horizontal moves" do
-      expect(rook.valid_move?(0, 0)).to be true
+      expect(rook.move_legal?(0, 0)).to be true
     end
 
     it "should not allow an illegal move" do
-      expect(rook.valid_move?(2, 2)).to be false
+      expect(rook.move_legal?(2, 2)).to be false
     end
   end
 end


### PR DESCRIPTION
added methods move_destination_same_side? to replace move_destination_obstructed? from valid_move PR. Also changed order of calls in valid_move?. Decided to check if destination square contains same-side piece - and not bother with move_legal?

Changed move_to! to return a boolean which is used by PiecesController::update to determine if the $.post returned success or an error. With an error, the jQuery should return the piece to its original location. This is not written yet.

I reworked capture code (sorry John). There no longer is a need to check if the piece in the square is on the same side. That is done in move_destination_same_side?. I also moved the capture methods into private since nothing outside of the piece class should ever call it. So ran into a problem with the captured! method. See comment in the code. I update the is_captured attribute on the captured_piece to true within capture_piece!. I did move the method captured? to public because another model might want to know the status. 

I broked the move_obstructed? logic into four methods: the main methods and three methods that created obstruction_array. Rubocop was going insane with complexity errors on a long, single method. 

I still ended up with a lot of rubocop complexity errors and class/method too many lines. I don't know what to do with those. I also have useless assignments to piece2 in piece_spec.rb; however, I need those pieces to obstruct movement and/or occupy the destination square.

I have added tests. Because of my capture changes, the two capture tests now fails. I will either undo my capture code in piece.rb or update the tests in piece_spec.rb.

Ready for your comments.

Question 1: Should the piece sub-classes implement their own move_obstructed? method or create the obstruction_array and make the array available to the parent class?

Question 2: Let's discuss how to capture a piece during the session today. It doesn't feel right yet.
